### PR TITLE
Unify tax calculations for bathroom earnings

### DIFF
--- a/app/DTO/CalculationResult.php
+++ b/app/DTO/CalculationResult.php
@@ -10,9 +10,9 @@ final class CalculationResult
         public readonly int $dailyMinutesSpent,
         public readonly int $monthlyMinutesSpent,
         public readonly int $yearlyMinutesSpent,
-        public readonly float $dailyEarnings,
-        public readonly float $monthlyEarnings,
-        public readonly float $yearlyEarnings,
+        public readonly SalaryBreakdown $dailySalary,
+        public readonly SalaryBreakdown $monthlySalary,
+        public readonly SalaryBreakdown $yearlySalary,
         public readonly float $dailyShiftPercentage
     ) {
     }

--- a/app/DTO/SalaryBreakdown.php
+++ b/app/DTO/SalaryBreakdown.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+final class SalaryBreakdown
+{
+    public function __construct(
+        public readonly float $grossEarnings,
+        public readonly float $netEarnings,
+        public readonly float $inss,
+        public readonly float $irrf
+    ) {
+    }
+}

--- a/app/Services/CalculatorService.php
+++ b/app/Services/CalculatorService.php
@@ -22,9 +22,7 @@ final class CalculatorService
         $monthlyMinutes = $this->salaryCalculator->calculateMinutesSpent($king, 'MONTHLY');
         $yearlyMinutes = $this->salaryCalculator->calculateMinutesSpent($king, 'YEARLY');
 
-        $dailyEarnings = round($this->salaryCalculator->calculateTotalEarningsInBathroom($king, 'DAILY'), 2);
-        $monthlyEarnings = round($this->salaryCalculator->calculateTotalEarningsInBathroom($king, 'MONTHLY'), 2);
-        $yearlyEarnings = round($this->salaryCalculator->calculateTotalEarningsInBathroom($king, 'YEARLY'), 2);
+        $breakdowns = $this->salaryCalculator->calculateBreakdowns($king);
 
         $minutesWorked = WorkSchedule::getMinutesWorked($king->workSchedule, 'DAILY');
         $dailyPercentage = round($this->bathroomCalculator->calculateDailyPercentageOfShift(
@@ -37,9 +35,9 @@ final class CalculatorService
             $dailyMinutes,
             $monthlyMinutes,
             $yearlyMinutes,
-            $dailyEarnings,
-            $monthlyEarnings,
-            $yearlyEarnings,
+            $breakdowns['DAILY'],
+            $breakdowns['MONTHLY'],
+            $breakdowns['YEARLY'],
             $dailyPercentage
         );
     }

--- a/app/Services/SalaryCalculator.php
+++ b/app/Services/SalaryCalculator.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\DTO\KingData;
+use App\DTO\SalaryBreakdown;
 use App\Domain\WorkSchedule;
 
 final class SalaryCalculator
 {
+    public function __construct(
+        private readonly TaxCalculator $taxCalculator = new TaxCalculator(),
+    ) {
+    }
+
     public function calculateMinutesSpent(KingData $king, string $shiftTime): int
     {
         $minutesPerDay = $king->averageBathroomTime * $king->numberOfVisitsPerDay;
@@ -21,31 +27,107 @@ final class SalaryCalculator
         };
     }
 
-    public function calculateSalaryPerMinute(KingData $king): float
+    /**
+     * @return array<string, SalaryBreakdown>
+     */
+    public function calculateBreakdowns(KingData $king): array
+    {
+        $perMinuteValues = $this->calculatePerMinuteValues($king);
+        $breakdowns = [];
+
+        foreach (['DAILY', 'MONTHLY', 'YEARLY'] as $shiftTime) {
+            $minutesSpent = $this->calculateMinutesSpent($king, $shiftTime);
+
+            $breakdowns[$shiftTime] = new SalaryBreakdown(
+                round($perMinuteValues['gross'] * $minutesSpent, 2),
+                round($perMinuteValues['net'] * $minutesSpent, 2),
+                round($perMinuteValues['inss'] * $minutesSpent, 2),
+                round($perMinuteValues['irrf'] * $minutesSpent, 2),
+            );
+        }
+
+        return $breakdowns;
+    }
+
+    /**
+     * @return array{gross: float, net: float, inss: float, irrf: float}
+     */
+    private function calculatePerMinuteValues(KingData $king): array
     {
         $schedule = WorkSchedule::get($king->workSchedule);
         if ($schedule === null) {
-            return 0.0;
+            return ['gross' => 0.0, 'net' => 0.0, 'inss' => 0.0, 'irrf' => 0.0];
         }
 
+        $minutesPerShift = (int) ($schedule['minutesPerShift'] ?? 0);
+        $daysPerMonth = (int) ($schedule['daysPerMonth'] ?? 0);
+        if ($minutesPerShift <= 0 || $daysPerMonth <= 0) {
+            return ['gross' => 0.0, 'net' => 0.0, 'inss' => 0.0, 'irrf' => 0.0];
+        }
+
+        $monthlyMinutes = $minutesPerShift * $daysPerMonth;
+        $monthlySalary = $this->calculateMonthlySalary($king, $schedule);
+        if ($monthlyMinutes <= 0 || $monthlySalary <= 0) {
+            return ['gross' => 0.0, 'net' => 0.0, 'inss' => 0.0, 'irrf' => 0.0];
+        }
+
+        $taxes = $this->taxCalculator->calculateMonthlyTaxes($monthlySalary);
+        $monthlyNet = max(0.0, $monthlySalary - $taxes['inss'] - $taxes['irrf']);
+
+        return [
+            'gross' => $monthlySalary / $monthlyMinutes,
+            'net' => $monthlyNet / $monthlyMinutes,
+            'inss' => $taxes['inss'] / $monthlyMinutes,
+            'irrf' => $taxes['irrf'] / $monthlyMinutes,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $schedule
+     */
+    private function calculateMonthlySalary(KingData $king, ?array $schedule = null): float
+    {
+        $schedule ??= WorkSchedule::get($king->workSchedule);
+
         return match ($king->salaryType) {
-            'HOURLY' => $king->salary / 60,
-            'DAILY' => $king->salary / $schedule['minutesPerShift'],
-            'MONTHLY' => $schedule['daysPerMonth'] > 0
-                ? $king->salary / ($schedule['minutesPerShift'] * $schedule['daysPerMonth'])
+            'HOURLY' => ($schedule !== null)
+                ? $this->calculateHourlySalaryToMonthly($king->salary, $schedule)
                 : 0.0,
-            'YEARLY' => $schedule['daysPerYear'] > 0
-                ? $king->salary / ($schedule['minutesPerShift'] * $schedule['daysPerYear'])
+            'DAILY' => ($schedule !== null)
+                ? $this->calculateDailySalaryToMonthly($king->salary, $schedule)
                 : 0.0,
+            'MONTHLY' => max(0.0, $king->salary),
+            'YEARLY' => max(0.0, $king->salary / 12),
             default => 0.0,
         };
     }
 
-    public function calculateTotalEarningsInBathroom(KingData $king, string $shiftTime): float
+    /**
+     * @param array<string, mixed> $schedule
+     */
+    private function calculateHourlySalaryToMonthly(float $salary, array $schedule): float
     {
-        $salaryPerMinute = $this->calculateSalaryPerMinute($king);
-        $minutesSpent = $this->calculateMinutesSpent($king, $shiftTime);
+        $minutesPerShift = (int) ($schedule['minutesPerShift'] ?? 0);
+        $daysPerMonth = (int) ($schedule['daysPerMonth'] ?? 0);
+        if ($minutesPerShift <= 0 || $daysPerMonth <= 0) {
+            return 0.0;
+        }
 
-        return $salaryPerMinute * $minutesSpent;
+        $hoursPerShift = $minutesPerShift / 60;
+
+        return max(0.0, $salary * $hoursPerShift * $daysPerMonth);
+    }
+
+    /**
+     * @param array<string, mixed> $schedule
+     */
+    private function calculateDailySalaryToMonthly(float $salary, array $schedule): float
+    {
+        $daysPerMonth = (int) ($schedule['daysPerMonth'] ?? 0);
+        if ($daysPerMonth <= 0) {
+            return 0.0;
+        }
+
+        return max(0.0, $salary * $daysPerMonth);
     }
 }

--- a/app/Services/TaxCalculator.php
+++ b/app/Services/TaxCalculator.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+final class TaxCalculator
+{
+    /**
+     * INSS progressive brackets for 2024.
+     * @var array<int, array{limit: float, rate: float}>
+     */
+    private const INSS_BRACKETS = [
+        ['limit' => 1412.00, 'rate' => 0.075],
+        ['limit' => 2666.68, 'rate' => 0.09],
+        ['limit' => 4000.03, 'rate' => 0.12],
+        ['limit' => 7786.02, 'rate' => 0.14],
+    ];
+
+    /**
+     * IRRF table with the simplified discount already considered (2024).
+     * @var array<int, array{limit: float|null, rate: float, deduction: float}>
+     */
+    private const IRRF_TABLE = [
+        ['limit' => 2259.20, 'rate' => 0.0, 'deduction' => 0.0],
+        ['limit' => 2826.65, 'rate' => 0.075, 'deduction' => 169.44],
+        ['limit' => 3751.05, 'rate' => 0.15, 'deduction' => 381.44],
+        ['limit' => 4664.68, 'rate' => 0.225, 'deduction' => 662.77],
+        ['limit' => null, 'rate' => 0.275, 'deduction' => 896.00],
+    ];
+
+    private const IRRF_SIMPLIFIED_DEDUCTION = 528.00;
+
+    /**
+     * @return array{inss: float, irrf: float}
+     */
+    public function calculateMonthlyTaxes(float $monthlySalary): array
+    {
+        if ($monthlySalary <= 0) {
+            return ['inss' => 0.0, 'irrf' => 0.0];
+        }
+
+        $inss = $this->calculateInss($monthlySalary);
+        $taxableBase = max(0.0, $monthlySalary - $inss - self::IRRF_SIMPLIFIED_DEDUCTION);
+        $irrf = $this->calculateIrrf($taxableBase);
+
+        return [
+            'inss' => $inss,
+            'irrf' => $irrf,
+        ];
+    }
+
+    private function calculateInss(float $monthlySalary): float
+    {
+        $previousLimit = 0.0;
+        $total = 0.0;
+
+        foreach (self::INSS_BRACKETS as $bracket) {
+            $limit = $bracket['limit'];
+            $rate = $bracket['rate'];
+
+            if ($monthlySalary <= $previousLimit) {
+                break;
+            }
+
+            $portion = min($monthlySalary, $limit) - $previousLimit;
+            if ($portion > 0) {
+                $total += $portion * $rate;
+            }
+
+            $previousLimit = $limit;
+        }
+
+        return $total;
+    }
+
+    private function calculateIrrf(float $taxableBase): float
+    {
+        if ($taxableBase <= 0) {
+            return 0.0;
+        }
+
+        foreach (self::IRRF_TABLE as $bracket) {
+            $limit = $bracket['limit'];
+            $rate = $bracket['rate'];
+            $deduction = $bracket['deduction'];
+
+            if ($limit !== null && $taxableBase > $limit) {
+                continue;
+            }
+
+            $value = ($taxableBase * $rate) - $deduction;
+            return max(0.0, $value);
+        }
+
+        return 0.0;
+    }
+}

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -291,6 +291,12 @@ img {
     gap: 0.6rem;
 }
 
+.result-card__note {
+    margin: 0.75rem 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+}
+
 .results__empty {
     color: var(--color-text-muted);
 }
@@ -432,7 +438,7 @@ img {
     }
 
     .results__grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
     .seo-section__grid {

--- a/public/index.php
+++ b/public/index.php
@@ -170,10 +170,43 @@ require BASE_PATH . '/templates/partials/header.php';
                 <article class="result-card">
                     <h3>Ganhos no trono</h3>
                     <ul>
-                        <li><strong>Diário:</strong> <?= sanitize_output(format_currency($result->dailyEarnings)); ?></li>
-                        <li><strong>Mensal:</strong> <?= sanitize_output(format_currency($result->monthlyEarnings)); ?></li>
-                        <li><strong>Anual:</strong> <?= sanitize_output(format_currency($result->yearlyEarnings)); ?></li>
+                        <li>
+                            <strong>Diário:</strong>
+                            <?= sanitize_output(format_currency($result->dailySalary->netEarnings)); ?> líquidos
+                            (<?= sanitize_output(format_currency($result->dailySalary->grossEarnings)); ?> brutos)
+                        </li>
+                        <li>
+                            <strong>Mensal:</strong>
+                            <?= sanitize_output(format_currency($result->monthlySalary->netEarnings)); ?> líquidos
+                            (<?= sanitize_output(format_currency($result->monthlySalary->grossEarnings)); ?> brutos)
+                        </li>
+                        <li>
+                            <strong>Anual:</strong>
+                            <?= sanitize_output(format_currency($result->yearlySalary->netEarnings)); ?> líquidos
+                            (<?= sanitize_output(format_currency($result->yearlySalary->grossEarnings)); ?> brutos)
+                        </li>
                     </ul>
+                </article>
+                <article class="result-card">
+                    <h3>Tributos proporcionais</h3>
+                    <ul>
+                        <li>
+                            <strong>Diário:</strong>
+                            INSS <?= sanitize_output(format_currency($result->dailySalary->inss)); ?> ·
+                            IRRF <?= sanitize_output(format_currency($result->dailySalary->irrf)); ?>
+                        </li>
+                        <li>
+                            <strong>Mensal:</strong>
+                            INSS <?= sanitize_output(format_currency($result->monthlySalary->inss)); ?> ·
+                            IRRF <?= sanitize_output(format_currency($result->monthlySalary->irrf)); ?>
+                        </li>
+                        <li>
+                            <strong>Anual:</strong>
+                            INSS <?= sanitize_output(format_currency($result->yearlySalary->inss)); ?> ·
+                            IRRF <?= sanitize_output(format_currency($result->yearlySalary->irrf)); ?>
+                        </li>
+                    </ul>
+                    <p class="result-card__note">Valores proporcionais à parte do salário conquistada no trono.</p>
                 </article>
                 <article class="result-card">
                     <h3>Impacto no expediente</h3>


### PR DESCRIPTION
## Summary
- add a dedicated TaxCalculator and SalaryBreakdown DTO to centralise INSS/IRRF logic
- update SalaryCalculator/CalculatorService to reuse the unified breakdowns across shifts
- surface gross vs net earnings and proportional tax values in the UI with responsive styling tweaks

## Testing
- php -l app/DTO/SalaryBreakdown.php
- php -l app/Services/TaxCalculator.php
- php -l app/Services/SalaryCalculator.php
- php -l app/Services/CalculatorService.php
- php -l app/DTO/CalculationResult.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68caf01e284083298759d3a5cbf811ae