### PR TITLE
Implement Trono Remunerado MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=trono
+DB_USERNAME=usuario
+DB_PASSWORD=senha
+IP_HASH_SALT=mude-este-sal

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/.idea/
+/.vscode/
+.env
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Trono Remunerado
+
+Calculadora bem-humorada que estima quanto tempo e quanto dinheiro o trabalhador "ganha" no trono, respeitando a escala de trabalho. Projeto em PHP 8.2 + MySQL, mobile-first e com foco em SEO.
+
+## Requisitos
+- PHP 8.2+
+- MySQL 8+
+- Extensões PHP: `pdo_mysql`, `intl`
+
+## Configuração
+1. Copie o arquivo `.env.example` (crie o seu) com as variáveis:
+   ```bash
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=trono
+   DB_USERNAME=usuario
+   DB_PASSWORD=senha
+   IP_HASH_SALT=salto-secreto
+   ```
+2. Execute a migration `database/migrations/001_create_submissions.sql` no banco.
+3. Configure o servidor web para apontar para o diretório `public/`.
+
+## Testes
+Os testes de domínio utilizam PHPUnit (`tests/Domain/CalculatorTest.php`). Instale as dependências com Composer e execute `vendor/bin/phpunit`. Em ambientes sem acesso à internet, instale as dependências localmente antes do deploy.

--- a/app/Assets/css/app.css
+++ b/app/Assets/css/app.css
@@ -1,0 +1,278 @@
+:root {
+  --c-bg: #F7F3EF;
+  --c-brown-600: #6E4E37;
+  --c-brown-400: #A67C52;
+  --c-gold: #C8A24A;
+  --c-ink: #1C1B1A;
+  --c-success: #2E7D32;
+  --radius: 18px;
+  --shadow: 0 10px 30px rgba(110, 78, 55, 0.12);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--c-bg);
+  color: var(--c-ink);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: var(--c-brown-600);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  padding: 1.5rem 0 1rem;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.logo-text {
+  color: var(--c-brown-600);
+}
+
+.site-nav a {
+  font-weight: 600;
+}
+
+.hero {
+  padding: 0 0 2rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 6vw, 2.8rem);
+  margin-bottom: 0.5rem;
+  color: var(--c-brown-600);
+}
+
+.hero p {
+  margin: 0 auto;
+  max-width: 40rem;
+  color: rgba(28, 27, 26, 0.75);
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(110, 78, 55, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 1rem;
+}
+
+.form-hint {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(28, 27, 26, 0.6);
+}
+
+.button-primary {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 1rem;
+  background: linear-gradient(135deg, var(--c-brown-600), var(--c-brown-400));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(110, 78, 55, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary:hover,
+.button-primary:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(110, 78, 55, 0.28);
+}
+
+.result-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.result-card::before {
+  content: '👑';
+  position: absolute;
+  top: -24px;
+  right: 20px;
+  font-size: 4rem;
+  opacity: 0.2;
+}
+
+.result-highlight {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--c-brown-600);
+}
+
+.progress {
+  height: 10px;
+  background: rgba(198, 162, 74, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 1rem 0;
+}
+
+.progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--c-gold), var(--c-brown-400));
+}
+
+.rankings-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.rankings-tabs button {
+  flex: 1;
+  padding: 0.75rem;
+  background: rgba(198, 162, 74, 0.1);
+  border: 1px solid rgba(198, 162, 74, 0.4);
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.rankings-tabs button.is-active {
+  background: var(--c-gold);
+  color: var(--c-ink);
+}
+
+.leaderboard {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.leaderboard-group {
+  margin-bottom: 1.5rem;
+}
+
+.leaderboard-group h3 {
+  margin-bottom: 0.5rem;
+  color: var(--c-brown-600);
+}
+
+.leaderboard li {
+  display: flex;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.badge-scale {
+  font-size: 0.75rem;
+  background: rgba(110, 78, 55, 0.15);
+  color: var(--c-brown-600);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+}
+
+.site-footer {
+  padding: 2rem 0 3rem;
+  background: rgba(110, 78, 55, 0.1);
+  margin-top: 3rem;
+}
+
+.site-footer h2 {
+  color: var(--c-brown-600);
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.educational ul {
+  padding-left: 1.2rem;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(46, 125, 50, 0.12);
+  color: var(--c-success);
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 720px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .form-grid .form-group.full {
+    grid-column: 1 / -1;
+  }
+}

--- a/app/Assets/js/app.js
+++ b/app/Assets/js/app.js
@@ -1,0 +1,45 @@
+(function () {
+  const tabButtons = document.querySelectorAll('[data-tab-target]');
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.tabTarget;
+      document.querySelectorAll('[data-tab-panel]').forEach((panel) => {
+        panel.hidden = panel.dataset.tabPanel !== target;
+      });
+      tabButtons.forEach((btn) => btn.classList.toggle('is-active', btn === button));
+    });
+  });
+
+  const shareButton = document.querySelector('[data-share]');
+  if (shareButton && navigator.share) {
+    shareButton.addEventListener('click', async () => {
+      try {
+        await navigator.share({
+          title: document.title,
+          text: shareButton.dataset.shareText || 'Olha meu reinado no Trono Remunerado!',
+          url: window.location.href,
+        });
+      } catch (error) {
+        console.warn('Compartilhamento cancelado', error);
+      }
+    });
+  }
+
+  const form = document.querySelector('[data-throne-form]');
+  if (form) {
+    let lastSubmit = 0;
+    form.addEventListener('submit', (event) => {
+      const now = Date.now();
+      if (now - lastSubmit < 3000) {
+        event.preventDefault();
+        const alert = document.createElement('div');
+        alert.className = 'alert';
+        alert.textContent = 'Segura a coroa! Espere um instante antes de enviar de novo.';
+        form.prepend(alert);
+        setTimeout(() => alert.remove(), 3000);
+        return;
+      }
+      lastSubmit = now;
+    });
+  }
+})();

--- a/app/Config/DB.php
+++ b/app/Config/DB.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Config;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class DB
+{
+    private static ?PDO $pdo = null;
+
+    public static function connection(): PDO
+    {
+        if (self::$pdo instanceof PDO) {
+            return self::$pdo;
+        }
+
+        $host = getenv('DB_HOST') ?: '127.0.0.1';
+        $port = getenv('DB_PORT') ?: '3306';
+        $database = getenv('DB_DATABASE') ?: '';
+        $username = getenv('DB_USERNAME') ?: '';
+        $password = getenv('DB_PASSWORD') ?: '';
+        $charset = 'utf8mb4';
+
+        if ($database === '' || $username === '') {
+            throw new RuntimeException('Database credentials are not configured.');
+        }
+
+        $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=%s', $host, $port, $database, $charset);
+
+        try {
+            self::$pdo = new PDO($dsn, $username, $password, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to connect to the database: ' . $exception->getMessage(), 0, $exception);
+        }
+
+        return self::$pdo;
+    }
+}

--- a/app/Domain/Calculator.php
+++ b/app/Domain/Calculator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Domain;
+
+use InvalidArgumentException;
+
+class Calculator
+{
+    /**
+     * @param float $salary Netto salary (not persisted)
+     * @param int $minutesPerDay Minutes spent on the throne per working day
+     * @param string $scaleCode One of the supported scales
+     * @param float|null $customHoursPerDay Optional override for hours per working day
+     * @return array<string, float|int|string>
+     */
+    public function calculate(float $salary, int $minutesPerDay, string $scaleCode, ?float $customHoursPerDay = null): array
+    {
+        if ($salary <= 0.0) {
+            throw new InvalidArgumentException('Salário deve ser maior que zero.');
+        }
+
+        if ($minutesPerDay < 1) {
+            throw new InvalidArgumentException('Minutos por dia deve ser positivo.');
+        }
+
+        $scale = Scales::get($scaleCode);
+        $hoursPerDay = $customHoursPerDay !== null ? max(1.0, min(24.0, $customHoursPerDay)) : (float) $scale['default_hours_per_day'];
+        $daysPerWeekPreset = $scale['days_per_week'] !== null ? (float) $scale['days_per_week'] : null;
+
+        $daysPerMonth = Scales::daysPerMonth($scaleCode, $daysPerWeekPreset);
+        $workHoursPerMonth = Scales::workHoursPerMonth($scaleCode, $hoursPerDay, $daysPerWeekPreset);
+
+        if ($workHoursPerMonth <= 0.0) {
+            throw new InvalidArgumentException('Horas trabalhadas no mês inválidas.');
+        }
+
+        $hourValue = $salary / $workHoursPerMonth;
+        $throneMinutesMonth = $minutesPerDay * $daysPerMonth;
+        $throneHoursMonth = $throneMinutesMonth / 60.0;
+        $throneMinutesYear = $throneMinutesMonth * 12;
+        $moneyMonth = round($throneHoursMonth * $hourValue, 2);
+        $moneyYear = round($moneyMonth * 12, 2);
+
+        return [
+            'scale_code' => $scaleCode,
+            'minutes_per_day' => $minutesPerDay,
+            'days_per_week' => $daysPerWeekPreset !== null
+                ? $daysPerWeekPreset
+                : round($daysPerMonth / 4.333, 2),
+            'hours_per_day' => $hoursPerDay,
+            'days_per_month' => round($daysPerMonth, 2),
+            'work_hours_per_month' => round($workHoursPerMonth, 2),
+            'throne_minutes_month' => (int) round($throneMinutesMonth),
+            'throne_minutes_year' => (int) round($throneMinutesYear),
+            'throne_hours_month' => $throneHoursMonth,
+            'hour_value' => $hourValue,
+            'throne_money_month' => $moneyMonth,
+            'throne_money_year' => $moneyYear,
+        ];
+    }
+}

--- a/app/Domain/Scales.php
+++ b/app/Domain/Scales.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Domain;
+
+use InvalidArgumentException;
+
+class Scales
+{
+    public const SCALE_VERSION = 1;
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function presets(): array
+    {
+        return [
+            '5x2' => [
+                'label' => '5x2 - expediente comum',
+                'days_per_week' => 5.0,
+                'default_hours_per_day' => 8.8,
+                'type' => 'weekly',
+                'legal_note' => '8h/44h CLT',
+            ],
+            '6x1' => [
+                'label' => '6x1 - comércio/serviços',
+                'days_per_week' => 6.0,
+                'default_hours_per_day' => 7.33,
+                'type' => 'weekly',
+                'legal_note' => 'Limite 44h semanais',
+            ],
+            '12x36' => [
+                'label' => '12x36 - plantões art. 59-A',
+                'days_per_week' => null,
+                'default_hours_per_day' => 12.0,
+                'type' => 'cyclical',
+                'cycle_ratio' => 0.5,
+                'legal_note' => 'Prevista no art. 59-A da CLT',
+            ],
+            '4x2' => [
+                'label' => '4x2 - operações contínuas',
+                'days_per_week' => null,
+                'default_hours_per_day' => 8.0,
+                'type' => 'cyclical',
+                'cycle_ratio' => 4 / 6,
+                'legal_note' => 'Escala comum em operações contínuas',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function get(string $code): array
+    {
+        $presets = self::presets();
+
+        if (!isset($presets[$code])) {
+            throw new InvalidArgumentException('Escala desconhecida.');
+        }
+
+        return $presets[$code];
+    }
+
+    /**
+     * Determina os dias trabalhados no mês para uma escala.
+     */
+    public static function daysPerMonth(string $code, float $daysPerWeek = null): float
+    {
+        if ($code === '5x2' || $code === '6x1') {
+            $presets = self::get($code);
+            $effectiveDays = $daysPerWeek ?? (float) $presets['days_per_week'];
+            return $effectiveDays * 4.333;
+        }
+
+        if ($code === '12x36') {
+            return 30.4375 * 0.5;
+        }
+
+        if ($code === '4x2') {
+            return 30.4375 * (4.0 / 6.0);
+        }
+
+        throw new InvalidArgumentException('Escala desconhecida.');
+    }
+
+    public static function workHoursPerMonth(string $code, float $hoursPerDay, float $daysPerWeek = null): float
+    {
+        if ($code === '5x2' || $code === '6x1') {
+            $presets = self::get($code);
+            $effectiveDays = $daysPerWeek ?? (float) $presets['days_per_week'];
+            return ($effectiveDays * $hoursPerDay) * 4.333;
+        }
+
+        $daysPerMonth = self::daysPerMonth($code, $daysPerWeek);
+        return $daysPerMonth * $hoursPerDay;
+    }
+}

--- a/app/Infra/SubmissionRepo.php
+++ b/app/Infra/SubmissionRepo.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Infra;
+
+use App\Config\DB;
+use App\Domain\Scales;
+use PDO;
+
+class SubmissionRepo
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = DB::connection();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function store(array $payload): int
+    {
+        $sql = 'INSERT INTO submissions (
+            nickname, scale_code, minutes_per_day, days_per_week, hours_per_day,
+            days_per_month, work_hours_per_month, throne_minutes_month, throne_minutes_year,
+            throne_money_month, throne_money_year, scale_version, ip_hash, user_agent
+        ) VALUES (
+            :nickname, :scale_code, :minutes_per_day, :days_per_week, :hours_per_day,
+            :days_per_month, :work_hours_per_month, :throne_minutes_month, :throne_minutes_year,
+            :throne_money_month, :throne_money_year, :scale_version, :ip_hash, :user_agent
+        )';
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            'nickname' => $payload['nickname'],
+            'scale_code' => $payload['scale_code'],
+            'minutes_per_day' => $payload['minutes_per_day'],
+            'days_per_week' => $payload['days_per_week'],
+            'hours_per_day' => $payload['hours_per_day'],
+            'days_per_month' => $payload['days_per_month'],
+            'work_hours_per_month' => $payload['work_hours_per_month'],
+            'throne_minutes_month' => $payload['throne_minutes_month'],
+            'throne_minutes_year' => $payload['throne_minutes_year'],
+            'throne_money_month' => $payload['throne_money_month'],
+            'throne_money_year' => $payload['throne_money_year'],
+            'scale_version' => Scales::SCALE_VERSION,
+            'ip_hash' => $payload['ip_hash'] ?? null,
+            'user_agent' => $payload['user_agent'] ?? null,
+        ]);
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM submissions WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        return $result === false ? null : $result;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function topTimeByScale(string $scaleCode, int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_minutes_month', 'DESC', $scaleCode, $limit);
+    }
+
+    public function topMoneyByScale(string $scaleCode, int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_money_month', 'DESC', $scaleCode, $limit);
+    }
+
+    public function shortReignsByScale(string $scaleCode, int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_minutes_month', 'ASC', $scaleCode, $limit);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function topTimeGlobal(int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_minutes_month', 'DESC', null, $limit);
+    }
+
+    public function topMoneyGlobal(int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_money_month', 'DESC', null, $limit);
+    }
+
+    public function shortReignsGlobal(int $limit = 5): array
+    {
+        return $this->fetchLeaderboard('throne_minutes_month', 'ASC', null, $limit);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchLeaderboard(string $column, string $direction, ?string $scaleCode, int $limit): array
+    {
+        $direction = strtoupper($direction) === 'ASC' ? 'ASC' : 'DESC';
+        $sql = 'SELECT nickname, scale_code, ' . $column . ' FROM submissions';
+        $params = [];
+        if ($scaleCode !== null) {
+            $sql .= ' WHERE scale_code = :scale_code';
+            $params['scale_code'] = $scaleCode;
+        }
+        $sql .= ' ORDER BY ' . $column . ' ' . $direction . ' LIMIT ' . (int) $limit;
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return $stmt->fetchAll();
+    }
+}

--- a/app/Support/Formatter.php
+++ b/app/Support/Formatter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support;
+
+use NumberFormatter;
+
+class Formatter
+{
+    public static function money(float $value): string
+    {
+        $formatter = new NumberFormatter('pt_BR', NumberFormatter::CURRENCY);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+        return $formatter->formatCurrency($value, 'BRL');
+    }
+
+    public static function minutesToHuman(int $minutes): string
+    {
+        $hours = intdiv($minutes, 60);
+        $remaining = $minutes % 60;
+        if ($hours === 0) {
+            return sprintf('%d min', $minutes);
+        }
+        if ($remaining === 0) {
+            return sprintf('%dh', $hours);
+        }
+        return sprintf('%dh%02d', $hours, $remaining);
+    }
+
+    public static function humanizeScale(string $code): string
+    {
+        $labels = [
+            '5x2' => '5x2',
+            '6x1' => '6x1',
+            '12x36' => '12x36',
+            '4x2' => '4x2',
+        ];
+
+        return $labels[$code] ?? $code;
+    }
+}

--- a/app/Support/InputSanitizer.php
+++ b/app/Support/InputSanitizer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Support;
+
+use NumberFormatter;
+use RuntimeException;
+
+class InputSanitizer
+{
+    public static function parseMoney(string $value): float
+    {
+        $formatter = new NumberFormatter('pt_BR', NumberFormatter::CURRENCY);
+        $clean = trim($value);
+        $currency = null;
+        $parsed = $formatter->parseCurrency($clean, $currency);
+        if ($parsed === false) {
+            $formatter = new NumberFormatter('pt_BR', NumberFormatter::DECIMAL);
+            $parsed = $formatter->parse($clean);
+        }
+        if ($parsed === false) {
+            throw new RuntimeException('Informe o salário líquido em reais.');
+        }
+
+        return (float) $parsed;
+    }
+
+    public static function parseInt(string $value): int
+    {
+        $int = filter_var($value, FILTER_VALIDATE_INT);
+        if ($int === false) {
+            throw new RuntimeException('Valor inteiro inválido.');
+        }
+
+        return (int) $int;
+    }
+
+    public static function parseFloat(string $value): float
+    {
+        $normalized = str_replace(',', '.', $value);
+        if (!is_numeric($normalized)) {
+            throw new RuntimeException('Número inválido.');
+        }
+
+        return (float) $normalized;
+    }
+}

--- a/app/Support/Security.php
+++ b/app/Support/Security.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support;
+
+use DateTimeImmutable;
+use RuntimeException;
+
+class Security
+{
+    private const RATE_LIMIT_SECONDS = 30;
+
+    public static function hashIp(string $ip, string $userAgent): ?string
+    {
+        if ($ip === '' && $userAgent === '') {
+            return null;
+        }
+
+        $salt = getenv('IP_HASH_SALT') ?: 'trono_salt';
+        $payload = $ip . '|' . $userAgent . '|' . $salt;
+
+        return hash('sha256', $payload);
+    }
+
+    public static function ensureNicknameIsSafe(string $nickname): void
+    {
+        $clean = trim($nickname);
+        if ($clean === '' || mb_strlen($clean) > 40) {
+            throw new RuntimeException('Escolha um apelido amigável de até 40 caracteres.');
+        }
+
+        if (preg_match('/https?:\/\//i', $clean)) {
+            throw new RuntimeException('Sem links no apelido, majestade.');
+        }
+
+        if (preg_match('/(.)\1{3,}/u', $clean)) {
+            throw new RuntimeException('Menos caracteres repetidos no apelido, por favor.');
+        }
+
+        if (!preg_match('/^[\p{L}0-9 _\-]{2,40}$/u', $clean)) {
+            throw new RuntimeException('Use apenas letras, números, espaços, hífens ou underscores.');
+        }
+    }
+
+    public static function ensureRateLimit(?string $hash): void
+    {
+        if ($hash === null) {
+            return;
+        }
+
+        $storageDir = sys_get_temp_dir() . '/trono-rate';
+        if (!is_dir($storageDir)) {
+            if (!mkdir($storageDir, 0755, true) && !is_dir($storageDir)) {
+                throw new RuntimeException('Não foi possível preparar o salão do rate limit.');
+            }
+        }
+
+        $file = $storageDir . '/' . $hash . '.lock';
+        $now = new DateTimeImmutable();
+
+        if (file_exists($file)) {
+            $last = (int) file_get_contents($file);
+            if ($now->getTimestamp() - $last < self::RATE_LIMIT_SECONDS) {
+                throw new RuntimeException('Trono ocupado! Aguarde 30 segundos antes de uma nova coroação.');
+            }
+        }
+
+        file_put_contents($file, (string) $now->getTimestamp());
+    }
+}

--- a/app/View/partials/footer.php
+++ b/app/View/partials/footer.php
@@ -1,0 +1,21 @@
+</main>
+<footer class="site-footer">
+    <div class="container">
+        <p>Estimativa lúdica com base nas escalas e nas referências da CLT (8h/44h; art. 59-A; art. 64). Este site não substitui orientação jurídica.</p>
+        <div class="footer-links">
+            <a href="/rankings.php#global">Ver rankings globais</a>
+            <a href="#educacao">Como calculamos</a>
+        </div>
+        <section id="educacao" class="educational">
+            <h2>Base legal do nosso reino</h2>
+            <ul>
+                <li><strong>12x36</strong>: prevista no art. 59-A da CLT.</li>
+                <li><strong>Fator 4,333 semanas/mês</strong>: aproximação clássica de RH para estimativas rápidas.</li>
+                <li><strong>Valor-hora (Art. 64)</strong>: salário mensal dividido pela duração contratual do trabalho.</li>
+                <li><strong>Jornadas usuais</strong>: 8h/dia e 44h/semana em diversas cartilhas oficiais.</li>
+            </ul>
+        </section>
+    </div>
+</footer>
+</body>
+</html>

--- a/app/View/partials/head.php
+++ b/app/View/partials/head.php
@@ -1,0 +1,43 @@
+<?php
+/** @var string $pageTitle */
+/** @var string $pageDescription */
+/** @var string $canonical */
+$pageTitle = $pageTitle ?? 'Trono Remunerado';
+$pageDescription = $pageDescription ?? 'Descubra quanto rende seu tempo real no banheiro.';
+$canonical = $canonical ?? '';
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($pageTitle, ENT_QUOTES) ?></title>
+    <meta name="description" content="<?= htmlspecialchars($pageDescription, ENT_QUOTES) ?>">
+    <?php if ($canonical): ?>
+        <link rel="canonical" href="<?= htmlspecialchars($canonical, ENT_QUOTES) ?>">
+    <?php endif; ?>
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="<?= htmlspecialchars($pageTitle, ENT_QUOTES) ?>">
+    <meta property="og:description" content="<?= htmlspecialchars($pageDescription, ENT_QUOTES) ?>">
+    <meta property="og:url" content="<?= htmlspecialchars($canonical ?: ($_SERVER['REQUEST_SCHEME'] ?? 'https') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost') . $_SERVER['REQUEST_URI'], ENT_QUOTES) ?>">
+    <meta property="og:image" content="/assets/social/trono-og.webp">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="<?= htmlspecialchars($pageTitle, ENT_QUOTES) ?>">
+    <meta name="twitter:description" content="<?= htmlspecialchars($pageDescription, ENT_QUOTES) ?>">
+    <link rel="preload" href="/assets/fonts/trono-display.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="/assets/css/app.css">
+    <script defer src="/assets/js/app.js"></script>
+</head>
+<body>
+<header class="site-header">
+    <div class="container">
+        <a href="/" class="logo" aria-label="Trono Remunerado">
+            <span aria-hidden="true">💩</span>
+            <span class="logo-text">Trono Remunerado</span>
+        </a>
+        <nav class="site-nav">
+            <a href="/rankings.php">Rankings</a>
+        </nav>
+    </div>
+</header>
+<main class="site-main container">

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/';
+
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+}
+
+mb_internal_encoding('UTF-8');
+setlocale(LC_TIME, 'pt_BR.UTF-8');

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "paidthrone/app",
+  "description": "Trono Remunerado - calculadora bem humorada.",
+  "type": "project",
+  "require": {
+    "php": "^8.2"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  }
+}

--- a/database/migrations/001_create_submissions.sql
+++ b/database/migrations/001_create_submissions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS submissions (
+  id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+  nickname VARCHAR(40) NOT NULL,
+  scale_code ENUM('5x2','6x1','12x36','4x2') NOT NULL,
+  minutes_per_day TINYINT UNSIGNED NOT NULL,
+  days_per_week DECIMAL(4,2) NOT NULL,
+  hours_per_day DECIMAL(4,2) NOT NULL,
+  days_per_month DECIMAL(6,2) NOT NULL,
+  work_hours_per_month DECIMAL(7,2) NOT NULL,
+  throne_minutes_month INT UNSIGNED NOT NULL,
+  throne_minutes_year INT UNSIGNED NOT NULL,
+  throne_money_month DECIMAL(12,2) NOT NULL,
+  throne_money_year DECIMAL(12,2) NOT NULL,
+  scale_version SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+  ip_hash CHAR(64) NULL,
+  user_agent VARCHAR(255) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX ix_scale_time (scale_code, throne_minutes_month DESC),
+  INDEX ix_scale_money (scale_code, throne_money_month DESC),
+  INDEX ix_short_reigns (scale_code, throne_minutes_month ASC),
+  INDEX ix_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1,0 +1,1 @@
+../../app/Assets/css/app.css

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1,0 +1,1 @@
+../../app/Assets/js/app.js

--- a/public/assets/social/trono-og.webp
+++ b/public/assets/social/trono-og.webp
@@ -1,0 +1,1 @@
+Placeholder image for social sharing.

--- a/public/calcular.php
+++ b/public/calcular.php
@@ -1,0 +1,80 @@
+<?php
+require __DIR__ . '/../app/bootstrap.php';
+
+use App\Domain\Calculator;
+use App\Domain\Scales;
+use App\Infra\SubmissionRepo;
+use App\Support\InputSanitizer;
+use App\Support\Security;
+
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /');
+    exit;
+}
+
+try {
+    $nickname = trim((string) filter_input(INPUT_POST, 'apelido', FILTER_SANITIZE_SPECIAL_CHARS));
+    $salaryRaw = (string) filter_input(INPUT_POST, 'salario');
+    $minutesRaw = (string) filter_input(INPUT_POST, 'minutos');
+    $scale = (string) filter_input(INPUT_POST, 'escala', FILTER_SANITIZE_SPECIAL_CHARS);
+    $hoursRaw = (string) filter_input(INPUT_POST, 'horas');
+
+    Security::ensureNicknameIsSafe($nickname);
+
+    $scales = Scales::presets();
+    if (!isset($scales[$scale])) {
+        throw new RuntimeException('Escala desconhecida.');
+    }
+
+    $salary = InputSanitizer::parseMoney($salaryRaw);
+    if ($salary < 1 || $salary > 1000000) {
+        throw new RuntimeException('Salário fora da faixa aceitável (R$ 1 a R$ 1.000.000).');
+    }
+
+    $minutesPerDay = InputSanitizer::parseInt($minutesRaw);
+    if ($minutesPerDay < 1 || $minutesPerDay > 120) {
+        throw new RuntimeException('Minutos por dia devem estar entre 1 e 120.');
+    }
+
+    $hoursPerDay = InputSanitizer::parseFloat($hoursRaw ?: (string) $scales[$scale]['default_hours_per_day']);
+    if ($hoursPerDay < 1 || $hoursPerDay > 24) {
+        throw new RuntimeException('Horas por dia devem estar entre 1 e 24.');
+    }
+
+    $ipHash = Security::hashIp($_SERVER['REMOTE_ADDR'] ?? '', $_SERVER['HTTP_USER_AGENT'] ?? '');
+    Security::ensureRateLimit($ipHash);
+
+    $calculator = new Calculator();
+    $results = $calculator->calculate($salary, $minutesPerDay, $scale, $hoursPerDay);
+
+    $repo = new SubmissionRepo();
+    $payload = array_merge($results, [
+        'nickname' => $nickname,
+        'ip_hash' => $ipHash,
+        'user_agent' => substr((string) ($_SERVER['HTTP_USER_AGENT'] ?? ''), 0, 255),
+    ]);
+    $submissionId = $repo->store($payload);
+
+    $_SESSION['last_result'] = [
+        'id' => $submissionId,
+        'nickname' => $nickname,
+        'hour_value' => $results['hour_value'],
+        'throne_hours_month' => $results['throne_hours_month'],
+    ];
+
+    header('Location: /resultado.php?id=' . $submissionId);
+    exit;
+} catch (\Throwable $exception) {
+    $_SESSION['form_error'] = $exception->getMessage();
+    $_SESSION['form_old'] = [
+        'apelido' => $nickname ?? '',
+        'salario' => $salaryRaw ?? '',
+        'minutos' => $minutesRaw ?? '',
+        'escala' => $scale ?? '5x2',
+        'horas' => $hoursRaw ?? '',
+    ];
+    header('Location: /');
+    exit;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,95 @@
+<?php
+require __DIR__ . '/../app/bootstrap.php';
+
+use App\Domain\Scales;
+
+session_start();
+$formError = $_SESSION['form_error'] ?? null;
+$old = $_SESSION['form_old'] ?? [];
+unset($_SESSION['form_error'], $_SESSION['form_old']);
+
+$pageTitle = 'Trono Remunerado - calcule quanto rende seu tempo no banheiro (por escala)';
+$pageDescription = 'Descubra quantos minutos por mês você reina no trono e quanto isso rende em dinheiro. Suporta 5x2, 6x1, 12x36 e 4x2. Rankings por escala e zero coleta de salário.';
+$canonical = ($_SERVER['REQUEST_SCHEME'] ?? 'https') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost') . '/';
+$scales = Scales::presets();
+include __DIR__ . '/../app/View/partials/head.php';
+?>
+<section class="hero">
+    <h1>Calcule o valor do seu reinado no trono 💩</h1>
+    <p>Informativo bem-humorado que transforma o tempo de banheiro em horas trabalhadas e reais. Rankings por escala, zero coleta de salário. É diversão com cheiro de justiça laboral.</p>
+</section>
+<section class="card">
+    <?php if ($formError): ?>
+        <div class="alert" role="alert"><?= htmlspecialchars($formError, ENT_QUOTES) ?></div>
+    <?php endif; ?>
+    <form action="/calcular.php" method="post" class="form-grid" data-throne-form>
+        <div class="form-group full">
+            <label for="apelido">Apelido real</label>
+            <input type="text" id="apelido" name="apelido" maxlength="40" required placeholder="Rainha do Flush, Rei da Faxina..." value="<?= htmlspecialchars((string) ($old['apelido'] ?? ''), ENT_QUOTES) ?>">
+        </div>
+        <div class="form-group">
+            <label for="salario">Salário líquido mensal (R$)</label>
+            <input type="text" id="salario" name="salario" required inputmode="decimal" placeholder="Ex.: 2500,00" aria-describedby="tooltip-salario" value="<?= htmlspecialchars((string) ($old['salario'] ?? ''), ENT_QUOTES) ?>">
+            <small class="form-hint" id="tooltip-salario">Usamos só para calcular o valor da hora. <strong>Nunca salvamos</strong> seu salário. Promessa de rei.</small>
+        </div>
+        <div class="form-group">
+            <label for="minutos">Tempo médio no trono por dia útil (min)</label>
+            <input type="number" id="minutos" name="minutos" required min="1" max="120" value="<?= htmlspecialchars((string) ($old['minutos'] ?? '10'), ENT_QUOTES) ?>">
+        </div>
+        <div class="form-group">
+            <label for="escala">Escala de trabalho</label>
+            <select id="escala" name="escala" required data-scale-select>
+                <?php foreach ($scales as $code => $scale): ?>
+                    <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>" data-default-hours="<?= htmlspecialchars((string) $scale['default_hours_per_day'], ENT_QUOTES) ?>" <?= (($old['escala'] ?? '5x2') === $code) ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($scale['label'], ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+            <small class="form-hint">Limite padrão CLT: 8h/dia e 44h/semana. Ajuste se sua jornada for diferente.</small>
+        </div>
+        <div class="form-group">
+            <label for="horas">Horas trabalhadas por dia</label>
+            <?php
+            $defaultHours = $scales['5x2']['default_hours_per_day'];
+            $hoursValue = $old['horas'] ?? $defaultHours;
+            ?>
+            <input type="number" id="horas" name="horas" step="0.01" min="1" max="24" value="<?= htmlspecialchars((string) $hoursValue, ENT_QUOTES) ?>" data-hours-input <?= ($old['horas'] ?? '') !== '' ? 'data-user-edited="true"' : '' ?>>
+        </div>
+        </div>
+        <div class="form-group full">
+            <button type="submit" class="button-primary">Entronizar agora</button>
+        </div>
+    </form>
+</section>
+<section class="card">
+    <h2>Como funciona?</h2>
+    <p>Transformamos seus minutos diários de trono em horas trabalhadas do mês e multiplicamos pelo valor da sua hora líquida (art. 64 da CLT). Tudo considerando os dias úteis da sua escala real — nada de meses cheios injustos.</p>
+    <ul>
+        <li><strong>Escalas justas</strong>: 5x2, 6x1, 12x36 e 4x2 com presets fiéis.</li>
+        <li><strong>Rankings por escala</strong>: compare-se com quem vive rotina parecida.</li>
+        <li><strong>Privacidade real</strong>: a base nunca guarda salário, apenas derivados.</li>
+    </ul>
+</section>
+<script>
+    const scaleSelect = document.querySelector('[data-scale-select]');
+    const hoursInput = document.querySelector('[data-hours-input]');
+    if (scaleSelect && hoursInput) {
+        const updateHours = () => {
+            const option = scaleSelect.options[scaleSelect.selectedIndex];
+            const defaultHours = option.getAttribute('data-default-hours');
+            if (defaultHours && !hoursInput.dataset.userEdited) {
+                hoursInput.value = defaultHours;
+            }
+        };
+        if (hoursInput.dataset.userEdited === 'true') {
+            hoursInput.dataset.userEdited = 'true';
+        } else {
+            hoursInput.addEventListener('input', () => {
+                hoursInput.dataset.userEdited = 'true';
+            }, { once: true });
+        }
+        scaleSelect.addEventListener('change', updateHours);
+        updateHours();
+    }
+</script>
+<?php include __DIR__ . '/../app/View/partials/footer.php';

--- a/public/rankings.php
+++ b/public/rankings.php
@@ -1,0 +1,138 @@
+<?php
+require __DIR__ . '/../app/bootstrap.php';
+
+use App\Domain\Scales;
+use App\Infra\SubmissionRepo;
+use App\Support\Formatter;
+
+$repo = new SubmissionRepo();
+$scales = Scales::presets();
+$selectedScale = $_GET['escala'] ?? '5x2';
+if ($selectedScale !== 'global' && !isset($scales[$selectedScale])) {
+    $selectedScale = '5x2';
+}
+
+$pageTitle = 'Rankings reais - Trono Remunerado';
+$pageDescription = 'Top 5 de tempo e dinheiro no trono por escala de trabalho, além do placar global. Compare-se com majestades da mesma rotina.';
+$canonical = ($_SERVER['REQUEST_SCHEME'] ?? 'https') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost') . '/rankings.php';
+include __DIR__ . '/../app/View/partials/head.php';
+?>
+<section class="card">
+    <h1>Rankings coroados por escala</h1>
+    <p>Justiça trabalhista exige comparações entre jornadas parecidas. Escolha sua escala abaixo para ver as majestades que reinam mais tempo ou arrecadam mais cacau.</p>
+    <div class="rankings-tabs">
+        <?php foreach ($scales as $code => $scale): ?>
+            <button type="button" data-tab-target="scale-<?= htmlspecialchars($code, ENT_QUOTES) ?>" class="<?= $selectedScale === $code ? 'is-active' : '' ?>"><?= htmlspecialchars($code, ENT_QUOTES) ?> 👑</button>
+        <?php endforeach; ?>
+        <button type="button" data-tab-target="global" class="<?= $selectedScale === 'global' ? 'is-active' : '' ?>">🌎 Global (todas as escalas)</button>
+    </div>
+    <?php foreach ($scales as $code => $scale):
+        $time = $repo->topTimeByScale($code);
+        $money = $repo->topMoneyByScale($code);
+        $short = $repo->shortReignsByScale($code);
+        ?>
+        <section data-tab-panel="scale-<?= htmlspecialchars($code, ENT_QUOTES) ?>" <?= $selectedScale === $code ? '' : 'hidden' ?>>
+            <h2><?= htmlspecialchars($scale['label'], ENT_QUOTES) ?></h2>
+            <div class="leaderboard-group">
+                <h3>👑 Tempo</h3>
+                <ol class="leaderboard">
+                    <?php if (empty($time)): ?>
+                        <li>Nenhum reinado registrado ainda.</li>
+                    <?php else: ?>
+                        <?php foreach ($time as $row): ?>
+                            <li><span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span><strong><?= Formatter::minutesToHuman((int) $row['throne_minutes_month']) ?></strong></li>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </ol>
+            </div>
+            <div class="leaderboard-group">
+                <h3>💰 Fortunas</h3>
+                <ol class="leaderboard">
+                    <?php if (empty($money)): ?>
+                        <li>Nenhum reinado registrado ainda.</li>
+                    <?php else: ?>
+                        <?php foreach ($money as $row): ?>
+                            <li><span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span><strong><?= Formatter::money((float) $row['throne_money_month']) ?></strong></li>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </ol>
+            </div>
+            <div class="leaderboard-group">
+                <h3>🥀 Reinos curtinhos</h3>
+                <ol class="leaderboard">
+                    <?php if (empty($short)): ?>
+                        <li>Nenhum reinado registrado ainda.</li>
+                    <?php else: ?>
+                        <?php foreach ($short as $row): ?>
+                            <li><span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span><strong><?= Formatter::minutesToHuman((int) $row['throne_minutes_month']) ?></strong></li>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </ol>
+            </div>
+        </section>
+    <?php endforeach; ?>
+    <?php
+    $globalTime = $repo->topTimeGlobal();
+    $globalMoney = $repo->topMoneyGlobal();
+    $globalShort = $repo->shortReignsGlobal();
+    ?>
+    <section data-tab-panel="global" <?= $selectedScale === 'global' ? '' : 'hidden' ?> id="global">
+        <h2>🌎 Global (todas as escalas)</h2>
+        <p class="form-hint">Comparação entre escalas pode ser injusta, use com senso de humor e responsabilidade.</p>
+        <div class="leaderboard-group">
+            <h3>👑 Tempo</h3>
+            <ol class="leaderboard">
+                <?php if (empty($globalTime)): ?>
+                    <li>Nenhum reinado registrado ainda.</li>
+                <?php else: ?>
+                    <?php foreach ($globalTime as $row): ?>
+                        <li>
+                            <span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span>
+                            <span>
+                                <?= Formatter::minutesToHuman((int) $row['throne_minutes_month']) ?>
+                                <span class="badge-scale"><?= htmlspecialchars($row['scale_code'], ENT_QUOTES) ?></span>
+                            </span>
+                        </li>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </ol>
+        </div>
+        <div class="leaderboard-group">
+            <h3>💰 Fortunas</h3>
+            <ol class="leaderboard">
+                <?php if (empty($globalMoney)): ?>
+                    <li>Nenhum reinado registrado ainda.</li>
+                <?php else: ?>
+                    <?php foreach ($globalMoney as $row): ?>
+                        <li>
+                            <span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span>
+                            <span>
+                                <?= Formatter::money((float) $row['throne_money_month']) ?>
+                                <span class="badge-scale"><?= htmlspecialchars($row['scale_code'], ENT_QUOTES) ?></span>
+                            </span>
+                        </li>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </ol>
+        </div>
+        <div class="leaderboard-group">
+            <h3>🥀 Reinos curtinhos</h3>
+            <ol class="leaderboard">
+                <?php if (empty($globalShort)): ?>
+                    <li>Nenhum reinado registrado ainda.</li>
+                <?php else: ?>
+                    <?php foreach ($globalShort as $row): ?>
+                        <li>
+                            <span><?= htmlspecialchars($row['nickname'], ENT_QUOTES) ?></span>
+                            <span>
+                                <?= Formatter::minutesToHuman((int) $row['throne_minutes_month']) ?>
+                                <span class="badge-scale"><?= htmlspecialchars($row['scale_code'], ENT_QUOTES) ?></span>
+                            </span>
+                        </li>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </ol>
+        </div>
+    </section>
+</section>
+<?php include __DIR__ . '/../app/View/partials/footer.php';

--- a/public/resultado.php
+++ b/public/resultado.php
@@ -1,0 +1,68 @@
+<?php
+require __DIR__ . '/../app/bootstrap.php';
+
+use App\Infra\SubmissionRepo;
+use App\Support\Formatter;
+
+session_start();
+
+$id = (int) ($_GET['id'] ?? 0);
+if ($id <= 0) {
+    header('Location: /');
+    exit;
+}
+
+$repo = new SubmissionRepo();
+$submission = $repo->find($id);
+
+if ($submission === null) {
+    header('Location: /');
+    exit;
+}
+
+$minutesMonth = (int) $submission['throne_minutes_month'];
+$minutesYear = (int) $submission['throne_minutes_year'];
+$moneyMonth = (float) $submission['throne_money_month'];
+$moneyYear = (float) $submission['throne_money_year'];
+$scaleCode = (string) $submission['scale_code'];
+$hoursDay = (float) $submission['hours_per_day'];
+$progress = min(100, max(0, ((int) $submission['minutes_per_day'] / 120) * 100));
+
+$hourValue = null;
+if (!empty($_SESSION['last_result']) && (int) $_SESSION['last_result']['id'] === $id) {
+    $hourValue = (float) $_SESSION['last_result']['hour_value'];
+    $throneHoursMonth = (float) $_SESSION['last_result']['throne_hours_month'];
+    unset($_SESSION['last_result']);
+} else {
+    $throneHoursMonth = $minutesMonth / 60.0;
+    $hourValue = $throneHoursMonth > 0 ? $moneyMonth / $throneHoursMonth : 0.0;
+}
+
+$pageTitle = 'Resultado do seu reinado - Trono Remunerado';
+$pageDescription = 'Veja quanto tempo e quanto dinheiro você conquistou no trono nesta escala.';
+$canonical = ($_SERVER['REQUEST_SCHEME'] ?? 'https') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost') . '/resultado.php?id=' . $id;
+include __DIR__ . '/../app/View/partials/head.php';
+?>
+<section class="card result-card">
+    <h1>Majestade, eis o seu relatório real!</h1>
+    <p class="result-highlight">🏰 Sua Majestade reinou <?= Formatter::minutesToHuman($minutesMonth) ?> neste mês (≈ <?= $minutesMonth ?> min).</p>
+    <p>Esse trono rendeu <strong><?= Formatter::money($moneyMonth) ?></strong>. Em 12 meses: <strong><?= Formatter::minutesToHuman($minutesYear) ?></strong> e <strong><?= Formatter::money($moneyYear) ?></strong>. Longa vida ao <strong>cag$flow real</strong>!</p>
+    <div class="progress" aria-hidden="true">
+        <span style="width: <?= htmlspecialchars(number_format($progress, 2, '.', ''), ENT_QUOTES) ?>%"></span>
+    </div>
+    <ul>
+        <li>Escala: <strong><?= htmlspecialchars($scaleCode, ENT_QUOTES) ?></strong> com <?= number_format($hoursDay, 2, ',', '.') ?>h/dia.</li>
+        <li>Valor-hora estimado: <strong><?= Formatter::money($hourValue) ?></strong>.</li>
+        <li>Dias trabalhados no mês da escala: <strong><?= number_format((float) $submission['days_per_month'], 2, ',', '.') ?></strong>.</li>
+    </ul>
+    <div class="cta-row">
+        <a class="button-primary" href="/rankings.php?escala=<?= urlencode($scaleCode) ?>">Ver rankings da minha escala</a>
+        <button type="button" class="button-primary" data-share data-share-text="<?= htmlspecialchars('Eu reino ' . Formatter::minutesToHuman($minutesMonth) . ' no Trono Remunerado!', ENT_QUOTES) ?>">Compartilhar</button>
+    </div>
+</section>
+<section class="card">
+    <h2>E agora?</h2>
+    <p>Compartilhe com a galera do trabalho, compare com colegas de escala e veja se o seu reinado merece um reajuste. Só não esqueça: estimativa lúdica com base na CLT — orientação jurídica é com profissionais.</p>
+    <p><a href="/">Calcular de novo</a> ou <a href="/rankings.php#global">espiar os rankings gerais</a>.</p>
+</section>
+<?php include __DIR__ . '/../app/View/partials/footer.php';

--- a/tests/Domain/CalculatorTest.php
+++ b/tests/Domain/CalculatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain;
+
+use App\Domain\Calculator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class CalculatorTest extends TestCase
+{
+    public function testCalculatesFor5x2Scale(): void
+    {
+        $calculator = new Calculator();
+        $result = $calculator->calculate(3000.00, 15, '5x2', 8.8);
+
+        $expectedDaysMonth = 5 * 4.333;
+        $expectedWorkHours = (5 * 8.8) * 4.333;
+        $expectedMinutes = (int) round(15 * $expectedDaysMonth);
+        $hourValue = 3000.00 / $expectedWorkHours;
+        $expectedMoneyMonth = round(($expectedMinutes / 60) * $hourValue, 2);
+
+        $this->assertEqualsWithDelta(round($expectedDaysMonth, 2), $result['days_per_month'], 0.01);
+        $this->assertEqualsWithDelta(round($expectedWorkHours, 2), $result['work_hours_per_month'], 0.01);
+        $this->assertSame($expectedMinutes, $result['throne_minutes_month']);
+        $this->assertEqualsWithDelta($expectedMoneyMonth, $result['throne_money_month'], 0.01);
+        $this->assertEqualsWithDelta($expectedMoneyMonth * 12, $result['throne_money_year'], 0.05);
+    }
+
+    public function testCalculatesFor6x1Scale(): void
+    {
+        $calculator = new Calculator();
+        $result = $calculator->calculate(2500.00, 12, '6x1', 7.33);
+
+        $expectedDaysMonth = 6 * 4.333;
+        $expectedWorkHours = (6 * 7.33) * 4.333;
+        $expectedMinutes = (int) round(12 * $expectedDaysMonth);
+        $hourValue = 2500.00 / $expectedWorkHours;
+        $expectedMoneyMonth = round(($expectedMinutes / 60) * $hourValue, 2);
+
+        $this->assertEqualsWithDelta(round($expectedDaysMonth, 2), $result['days_per_month'], 0.01);
+        $this->assertEqualsWithDelta(round($expectedWorkHours, 2), $result['work_hours_per_month'], 0.01);
+        $this->assertSame($expectedMinutes, $result['throne_minutes_month']);
+        $this->assertEqualsWithDelta($expectedMoneyMonth, $result['throne_money_month'], 0.01);
+    }
+
+    public function testCalculatesFor12x36Scale(): void
+    {
+        $calculator = new Calculator();
+        $result = $calculator->calculate(3200.00, 10, '12x36', 12.0);
+
+        $expectedDaysMonth = 30.4375 * 0.5;
+        $expectedWorkHours = $expectedDaysMonth * 12.0;
+        $expectedMinutes = (int) round(10 * $expectedDaysMonth);
+        $hourValue = 3200.00 / $expectedWorkHours;
+        $expectedMoneyMonth = round(($expectedMinutes / 60) * $hourValue, 2);
+
+        $this->assertEqualsWithDelta(round($expectedDaysMonth, 2), $result['days_per_month'], 0.01);
+        $this->assertEqualsWithDelta(round($expectedWorkHours, 2), $result['work_hours_per_month'], 0.01);
+        $this->assertSame($expectedMinutes, $result['throne_minutes_month']);
+        $this->assertEqualsWithDelta($expectedMoneyMonth, $result['throne_money_month'], 0.01);
+    }
+
+    public function testCalculatesFor4x2Scale(): void
+    {
+        $calculator = new Calculator();
+        $result = $calculator->calculate(2800.00, 8, '4x2', 8.0);
+
+        $expectedDaysMonth = 30.4375 * (4.0 / 6.0);
+        $expectedWorkHours = $expectedDaysMonth * 8.0;
+        $expectedMinutes = (int) round(8 * $expectedDaysMonth);
+        $hourValue = 2800.00 / $expectedWorkHours;
+        $expectedMoneyMonth = round(($expectedMinutes / 60) * $hourValue, 2);
+
+        $this->assertEqualsWithDelta(round($expectedDaysMonth, 2), $result['days_per_month'], 0.01);
+        $this->assertEqualsWithDelta(round($expectedWorkHours, 2), $result['work_hours_per_month'], 0.01);
+        $this->assertSame($expectedMinutes, $result['throne_minutes_month']);
+        $this->assertEqualsWithDelta($expectedMoneyMonth, $result['throne_money_month'], 0.01);
+    }
+
+    public function testRejectsInvalidSalary(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $calculator = new Calculator();
+        $calculator->calculate(0.0, 10, '5x2', 8.8);
+    }
+}


### PR DESCRIPTION
## Summary
- implement mobile-first landing, cálculo e páginas de resultado/rankings seguindo a paleta marrom e microcopy divertida
- adicionar domínio de escalas e calculadora com presets 5x2, 6x1, 12x36 e 4x2, garantindo persistência apenas de derivados
- criar repositório MySQL, camada de segurança (hash de IP, rate limit e validação de apelido) e testes de domínio para a calculadora

## Testing
- composer install *(falhou: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68cc94d942fc8329800ab63c239c361a